### PR TITLE
Pla 2338 ui fixes

### DIFF
--- a/js/audit.js
+++ b/js/audit.js
@@ -302,42 +302,54 @@ window.Audit = (function () {
             Object.keys(report).forEach(function (resId) {
                 Object.keys(report[resId].violations).forEach(function (violationKey) {
                     var rowData = report[resId].violations[violationKey];
-                    var alert = {
-                        title: rowData.display_name || violationKey,
-                        id: violationKey,
-                        level: rowData.level,
-                        category: rowData.category,
-                        description: rowData.description,
-                        fix: rowData.suggested_action,
-                        service: violations[violationKey].inputs.service,
-                        resource: { id: resId, tags: report[resId].tags, reportId: reportId },
-                        region: rowData.region,
-                        link: rowData.link,
-                        reportId: reportId,
-                        violationId: violations[violationKey]._id,
-                        isViolation: rowData.include_violations_in_count
-                    };
-                    if (!alertData.level.hasOwnProperty(alert.level)) {
-                        alertData.level[alert.level] = 0;
+                    if (violations[violationKey]) {
+                        rowData.violationId = violations[violationKey]._id;
+                        rowData.service = violations[violationKey].inputs.service;
                     }
-                    if (!alertData.category.hasOwnProperty(alert.category)) {
-                        alertData.category[alert.category] = 0;
-                    }
-                    if (!alertData.region.hasOwnProperty(alert.region)) {
-                        alertData.region[alert.region] = 0;
-                    }
-                    if (!alertData.service.hasOwnProperty(alert.service)) {
-                        alertData.service[alert.service] = 0;
-                    }
-                    ++alertData.level[alert.level];
-                    ++alertData.category[alert.category];
-                    ++alertData.region[alert.region];
-                    ++alertData.service[alert.service];
 
-                    alerts.push(alert);
-                    if (alert.isViolation) ++totalViolations;
-                    if (passedViolations[violationKey]) delete passedViolations[violationKey];
-                    if (disabledViolations[violationKey]) delete disabledViolations[violationKey];
+                    if (typeof rowData.include_violations_in_count === 'undefined') {
+                        rowData.include_violations_in_count = true;
+                    }
+
+                    var regionArray = rowData.region.trim().split(' ');
+                    regionArray.forEach( function(region) {
+                        var alert = {
+                            title: rowData.display_name || violationKey,
+                            id: violationKey,
+                            level: rowData.level,
+                            category: rowData.category,
+                            description: rowData.description,
+                            fix: rowData.suggested_action,
+                            service: rowData.service,
+                            resource: { id: resId, tags: report[resId].tags, reportId: reportId },
+                            region: region,
+                            link: rowData.link,
+                            reportId: reportId,
+                            violationId: rowData.violationId,
+                            isViolation: rowData.include_violations_in_count
+                        };
+                        if (!alertData.level.hasOwnProperty(alert.level)) {
+                            alertData.level[alert.level] = 0;
+                        }
+                        if (!alertData.category.hasOwnProperty(alert.category)) {
+                            alertData.category[alert.category] = 0;
+                        }
+                        if (!alertData.region.hasOwnProperty(alert.region)) {
+                            alertData.region[alert.region] = 0;
+                        }
+                        if (!alertData.service.hasOwnProperty(alert.service)) {
+                            alertData.service[alert.service] = 0;
+                        }
+                        ++alertData.level[alert.level];
+                        ++alertData.category[alert.category];
+                        ++alertData.region[alert.region];
+                        ++alertData.service[alert.service];
+
+                        alerts.push(alert);
+                        if (alert.isViolation) ++totalViolations;
+                        if (passedViolations[violationKey]) delete passedViolations[violationKey];
+                        if (disabledViolations[violationKey]) delete disabledViolations[violationKey];
+                    });
                 });
             });
         });

--- a/js/script.js
+++ b/js/script.js
@@ -74,6 +74,7 @@ $(document).ready(function () {
         var alerts = auditData.getViolationsList();
         if (alerts) {
             alerts.forEach(function (alert) {
+                if (!alert.isViolation) return;
                 var region = alert.region;
                 if (!mapData[region]) mapData[region] = { violations: 0, deployed: 0 };
                 ++mapData[region].violations;

--- a/js/static-map.js
+++ b/js/static-map.js
@@ -120,7 +120,7 @@ var regionsList = {
     'AWS': {region: 'Global'}
 };
 
-var mapCont = '.map-container'
+var mapCont = '.map-container';
 
 function moveToFront(elem) {
     return elem.each(function() {


### PR DESCRIPTION
PLA-2390:
It was added check for regions array. 
RESOURCES, MORE INFO and SHARE links will not work now for definitions created by jsrunner. Those links depend on alert id, and jsrunner definitions do not have any ids now. But they would have if it will be decided to define them as usual alerts

PLA-2338:
If include_violations_in_count is not defined, it would be recognized as true (in order to support previous versions)
Not counted violations were removed from map